### PR TITLE
fix: attempt to shift upload to build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,15 @@ jobs:
           --configfile config/config_for_github.yaml
           ./render --master-tex Snakemake_HPC_Admins.tex \
           --configfile config/config_for_github.yaml
+      - name: Upload Release Artifacts
+        if: ${{ steps.release.outputs.release_created }}        
+        uses: actions/upload-artifact@v4
+        with:
+          name: Slides
+          path: |
+            slides/*.pdf
+
+      
   release-please:
     runs-on: ubuntu-latest
     needs: build
@@ -43,10 +52,3 @@ jobs:
         with:
           release-type: simple
           package-name: "snakemake-hpc-teaching-material"
-      - name: Upload Release Artifacts
-        if: ${{ steps.release.outputs.release_created }}        
-        uses: actions/upload-artifact@v4
-        with:
-          name: Slides
-          path: |
-            slides/*.pdf


### PR DESCRIPTION
yet another attempt to enable slide (artifact) upload along source material

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new step in the release workflow to upload PDF slides as artifacts when a release is created.
- **Improvements**
	- Enhanced control flow for the upload process, ensuring it only occurs under specific conditions related to release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->