### PR TITLE
fix: handout production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout --sample-directory=_; 
           ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout --sample-directory=_;
-          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout --sample_directory=_;
+          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout --sample-directory=_;
           ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml --handout --sample-directory=_;
       
       - name: Certificate compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: LaTeX compile  
         run: |
-          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout --sample-directory=.; 
-          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
-          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
-          ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
+          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout --sample-directory=_; 
+          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout --sample-directory=_;
+          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout --sample_directory=_;
+          ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml --handout --sample-directory=_;
       
       - name: Certificate compile
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
 
       - name: LaTeX compile  
         run: |
-          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml ; 
-          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml
-          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml
+          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout; 
+          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout ;
+          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout ;
           ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml ;
       
       - name: Certificate compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
 
       - name: LaTeX compile  
         run: |
-          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout; 
-          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout ;
-          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout ;
-          ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml ;
+          ./render --master-tex Snakemake_HPC_Users.tex --configfile config/config_for_github.yaml --handout --sample-directory=.; 
+          ./render --master-tex Snakemake_HPC_Creators.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
+          ./render --master-tex Snakemake_HPC_User_Creator_Combi.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
+          ./render --master-tex Snakemake_HPC_Admins.tex --configfile config/config_for_github.yaml --handout --sample-directory=.;
       
       - name: Certificate compile
         run: |

--- a/config/config_for_github.yaml
+++ b/config/config_for_github.yaml
@@ -13,6 +13,7 @@ layout:
   beamercolor_title:      "fg=UniRot"
   beamercolor_title_head: "fg=UniRot"
 
+
   beamercolor_block_title: "bg=UniRot!20,fg=darkred"
   beamercolor_block_body:  "fg=black, bg=plightgrey2"
 
@@ -22,10 +23,11 @@ layout:
 # The configuration for github needs valid file strings!
 
 course:
-  date: "datestring" # maybe: "\today"
+  # sets the slides aspectratio (if outcommented, the default is 43=4:3)
+  aspectratio: 1609 # - 169 = 16:9
+  date: "\today" # maybe: "\today"
   #title: "" # specifiy your title here, else a default is used. 
   #subtitle: "" # specifiy your subtitle here, else a default is used. 
-  question: "yes"
   # Editors recommendations are a matter of taste and technological
   # setups (e.g. on-demand setups). Hence, specify an editor-slide,
   #  here:
@@ -36,7 +38,9 @@ course:
   condarcfile: "common/condarc_mogon.tex"
   # the same for admins:
   condarc_admins_file: "admin/condarc_mogon.tex"
-  # the following path will indicate a sample workflow for the user part
+  # We provide a common software stack to avoid long
+  # installation sessions.
+  softwarepath: "software-stack-path"
   # if it is defined, the slide set will instruct participants to copy
   # it and adapt its configuration and profile.
   pathtoworkflow: "/lustre/project/nhr-workflow/workflow"

--- a/render
+++ b/render
@@ -183,7 +183,9 @@ def find_and_replace_sections(boundaries, section_estimate, fname):
     if minitocline:
         lower = max((section_estimate - 2), 1)  # lower boundary not lower than 1
         upper = section_estimate + 2
-        upper = upper if upper < boundaries["upper"] else boundaries["upper"] + 1  # upper boundary not higher then upper boundary ;-)
+        upper = (
+            upper if upper < boundaries["upper"] else boundaries["upper"] + 1
+        )  # upper boundary not higher then upper boundary ;-)
         sections = f"{lower}-{upper}"
         lines[minitocline] = (
             "            \\tableofcontents[currentsection, sections={"
@@ -234,9 +236,15 @@ if __name__ == "__main__":
         "--sample-directory",
         help="needed with `--handout` - should indicate directory with script files (cloze and solution)",
     )
+    parser.add_argument(
+        "--no-packaging",
+        help="needed for the CI, which should not attempt to package slides",
+        default=False,
+        action=argparse.BooleanOptionalAction,
+    )
     args = parser.parse_args()
 
-    if args.handout and not args.sample_directory:
+    if args.handout and (not args.sample_directory or not args.no_packaging):
         print(
             "ERROR: must indicate --sample-directory when writing handouts",
             file=sys.stderr,
@@ -333,6 +341,9 @@ if __name__ == "__main__":
                 ("handout/README.txt", "README.txt"),
             ]
             opj = os.path.join
+
+            if args.no_packaging:
+                sys.exit(0)
 
             for root, dirs, files in os.walk(args.sample_directory):
                 for fname in files:

--- a/render
+++ b/render
@@ -236,15 +236,9 @@ if __name__ == "__main__":
         "--sample-directory",
         help="needed with `--handout` - should indicate directory with script files (cloze and solution)",
     )
-    parser.add_argument(
-        "--no-packaging",
-        help="needed for the CI, which should not attempt to package slides",
-        default=False,
-        action=argparse.BooleanOptionalAction,
-    )
     args = parser.parse_args()
 
-    if args.handout and (not args.sample_directory or not args.no_packaging):
+    if args.handout and not args.sample_directory:
         print(
             "ERROR: must indicate --sample-directory when writing handouts",
             file=sys.stderr,
@@ -342,7 +336,7 @@ if __name__ == "__main__":
             ]
             opj = os.path.join
 
-            if args.no_packaging:
+            if args.sample_directory == "_": # will skip producing a zip file
                 sys.exit(0)
 
             for root, dirs, files in os.walk(args.sample_directory):

--- a/render
+++ b/render
@@ -241,6 +241,7 @@ if __name__ == "__main__":
             "ERROR: must indicate --sample-directory when writing handouts",
             file=sys.stderr,
         )
+        sys.exit(1)
 
     # the master tex needs to be without the 'slides' path, because
     # on the tempfs, the relative path work without

--- a/render
+++ b/render
@@ -232,7 +232,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--sample-directory",
-        help="needed with `--handout` - should indicate directory with script file (cloze and solution)",
+        help="needed with `--handout` - should indicate directory with script files (cloze and solution)",
     )
     args = parser.parse_args()
 

--- a/setup_creators/condarc_mogon
+++ b/setup_creators/condarc_mogon
@@ -1,5 +1,3 @@
-create_default_packages:
-  - setuptools
 channels:
   - conda-forge
   - bioconda

--- a/slides/Snakemake_HPC_Admins.tex
+++ b/slides/Snakemake_HPC_Admins.tex
@@ -20,6 +20,14 @@
 
 \subtitle{<+++ if course.subtitle is defined +++><++course.subtitle++><+++else+++>Providing DataAnalytics Service<+++endif+++> - <++course.edition++>} 
 
+\ifdefined\ishandout
+\AddToHook{shipout/foreground}{
+	\begin{tikzpicture}[remember picture,overlay]
+		\node[red,rotate=10,scale=1,opacity=0.7] at (current page.center) {\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>}; 
+	\end{tikzpicture}
+}
+\fi
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}

--- a/slides/Snakemake_HPC_Creators.tex
+++ b/slides/Snakemake_HPC_Creators.tex
@@ -20,6 +20,14 @@
 
 \subtitle{<+++ if course.subtitle is defined +++><++course.subtitle++><+++else+++>Programming<+++endif+++> - <++course.edition++>} 
 
+\ifdefined\ishandout
+\AddToHook{shipout/foreground}{
+	\begin{tikzpicture}[remember picture,overlay]
+		\node[red,rotate=10,scale=1,opacity=0.7] at (current page.center) {\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>}; 
+	\end{tikzpicture}
+}
+\fi
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/slides/Snakemake_HPC_User_Creator_Combi.tex
+++ b/slides/Snakemake_HPC_User_Creator_Combi.tex
@@ -21,15 +21,20 @@
 \subtitle{<+++ if course.subtitle is defined +++><++course.subtitle++><+++else+++>Programming and Deployment<+++endif+++> - <++course.edition++>\newline by <++instructor.name++>} 
 
 \ifdefined\ishandout
-\usepackage{background}
-\backgroundsetup{
-	placement=center,
-	angle=30,
-	scale=1,
-	contents={\footnodesize Handout from Snakemake Teaching Alliance by <++instructor.name++>},
-	opacity=1
+\AddToHook{shipout/foreground}{
+	\begin{tikzpicture}[remember picture,overlay]
+		\node[red,rotate=10,scale=1,opacity=0.7] at (current page.center) {\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>}; 
+	\end{tikzpicture}
 }
-\setbeamertemplate{background}{\BgMaterial}
+%\usepackage{background}
+%\backgroundsetup{
+%	placement=center,
+%	angle=30,
+%	scale=1,
+%	contents={\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>},
+%	opacity=1
+%}
+%\setbeamertemplate{background}{\BgMaterial}
 \fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/slides/Snakemake_HPC_User_Creator_Combi.tex
+++ b/slides/Snakemake_HPC_User_Creator_Combi.tex
@@ -26,15 +26,6 @@
 		\node[red,rotate=10,scale=1,opacity=0.7] at (current page.center) {\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>}; 
 	\end{tikzpicture}
 }
-%\usepackage{background}
-%\backgroundsetup{
-%	placement=center,
-%	angle=30,
-%	scale=1,
-%	contents={\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>},
-%	opacity=1
-%}
-%\setbeamertemplate{background}{\BgMaterial}
 \fi
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/slides/Snakemake_HPC_Users.tex
+++ b/slides/Snakemake_HPC_Users.tex
@@ -20,6 +20,14 @@
 
 \subtitle{<+++ if course.subtitle is defined +++><++course.subtitle++><+++else+++>Deployment<+++endif+++> - <++course.edition++>} 
 
+\ifdefined\ishandout
+\AddToHook{shipout/foreground}{
+	\begin{tikzpicture}[remember picture,overlay]
+		\node[red,rotate=10,scale=1,opacity=0.7] at (current page.center) {\footnotesize Handout from Snakemake Teaching Alliance by <++instructor.name++>}; 
+	\end{tikzpicture}
+}
+\fi
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{document}


### PR DESCRIPTION
- Will render slides with `--handout` with watermark
- Will render autogenerated slides with `--handout`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised help text for the sample file directory option to provide clearer guidance.
- **Bug Fixes**
	- Improved error handling to ensure the application terminates immediately when required handout inputs are missing.
- **New Features**
	- Introduced a watermark for handout versions of documents, displaying the source and instructor's name.
	- Added configuration options for aspect ratio and software path in the settings.
- **Style**
	- Updated the visual presentation of handouts with a refreshed overlay effect, offering a modern and polished look.
- **Chores**
	- Removed default package specification from the conda environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->