### PR TITLE
fix: teaching elswhere questions

### DIFF
--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -8,7 +8,7 @@ This questionnaire helps to ask the right questions:
 
 - Organization:
   - Who is the contact for organizing this course? 
-  - If this is a topical course (e.g. for Bioinformaticicians, Physicist, etc.): Does the organization employ a support scientist for the intended topic? If so, which are the contact details?
+  - If this is a topical course (e.g. for Bioinformaticians, Physicist, etc.): Does the organization employ a support scientist for the intended topic? If so, which are the contact details?
 
 - What does the course room look like?
   - How many seats and PC-screens are available?

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -42,7 +42,7 @@ This questionnaire helps to ask the right questions:
   - Which partitions does the cluster provide for SMP programs (any restrictions for such software)?
   - Which partitions does the cluster provide for software (e.g. MPI) using >=1 full nodes?
   - How does the cluster support GPU application resource requests (special partitions? special SLURM flags?)?
-  - How long will the course run (number of days)? (our minimum is 2 days for the creator part and 1/2 day for the user part)
+  - How long will the course run (number of days)? (our minimum is 2 days for the full creator course and 1 day for the user-only course)
   - Does the cluster provide a scratch file system on compute nodes? If yes: what is the path?
 
 - Misc

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -15,8 +15,9 @@ This questionnaire helps to ask the right questions:
   - Is there a "Presenter PC"?
   - Is it possible to plug in a laptop? (HDMI and/or VGA?)
   - Please describe the "projector situation" (1 or more, need to have a key?).
-  - Does the lecturer need an adaptor for the projector?
+  - Does the lecturer need an adaptor for the video projector?
   - Is paired programming possible during the course considering the classroom's seating?
+  - Possibly: Which is the standard for power outlets? When the lecturer is teaching abroad.
 
 - Login and Security:
   - Which is the recommended software to log in? (putty, mobaxterm, powershell or plain ssh via Linux - or a terminal on demand)

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -9,6 +9,7 @@ This questionnaire helps to ask the right questions:
 - Organization:
   - Who is the contact for organizing this course? 
   - If this is a topical course (e.g. for Bioinformaticians, Physicist, etc.): Does the organization employ a support scientist for the intended topic? If so, which are the contact details?
+  - All participants need to be informed that they will need a GitHub account.
 
 - What does the course room look like?
   - How many seats and PC-screens are available?

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -4,7 +4,7 @@ Then send this questionnaire to your hosting site. Ask for all questions to be a
 
 ## Questionnaire
 
-This Questionnaire helps asking the right questions:
+This questionnaire helps to ask the right questions:
 
 - Organization:
   - Who is the contact for organizing this course? 

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -1,10 +1,10 @@
 # You need to teach this course on an - unknown - cluster?
 
-Then send this questionaire to your hosting site. Ask for all questions to be answered unless a public documention link can be provided, which answers these questions, partially.
+Then send this questionnaire to your hosting site. Ask for all questions to be answered unless a public documention link can be provided, which answers these questions, partially.
 
-## Questionaire
+## Questionnaire
 
-This questionaire helps asking the right questions:
+This Questionnaire helps asking the right questions:
 
 - Organization:
   - Who is the contact for organizing this course? 

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -1,6 +1,6 @@
 # You need to teach this course on an - unknown - cluster?
 
-Then send this questionnaire to your hosting site. Ask for all questions to be answered unless a public documention link can be provided, which answers these questions, partially.
+Then send this questionnaire to your hosting site. Ask for all questions to be answered unless a public documentation link can be provided, which answers these questions, partially.
 
 ## Questionnaire
 

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -32,7 +32,7 @@ This questionnaire helps to ask the right questions:
     - Will there be wifi? 
     -  Will there be power outlets?
 
-- Cluster Specialties
+- Cluster Specialities
   - May the course use a shared file space for the setup to be copied to? E.g. a workspace? Which are the quota limitations?
   - Are there quotas for the HOME directory (size, file number)?
   - Which compute node scratch mount points are provided (for stage-in/out)?

--- a/Teaching_Elsewhere.md
+++ b/Teaching_Elsewhere.md
@@ -16,7 +16,6 @@ This questionnaire helps to ask the right questions:
   - Is it possible to plug in a laptop? (HDMI and/or VGA?)
   - Please describe the "projector situation" (1 or more, need to have a key?).
   - Does the lecturer need an adaptor for the projector?
-  - Which is the OS for participant PCs? 
   - Is paired programming possible during the course considering the classroom's seating?
 
 - Login and Security:


### PR DESCRIPTION
various little fixes for the question set when teaching elsewhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling and improved phrasing for clarity throughout the document.
  - Added clarifications regarding GitHub account requirements and power outlet standards when teaching abroad.
  - Updated terminology and course duration descriptions for greater precision and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->